### PR TITLE
Fix cookie issue after rails 4.2.4 upgrade

### DIFF
--- a/app/models/lp_session.rb
+++ b/app/models/lp_session.rb
@@ -12,7 +12,7 @@ class LpSession
         key_generator     = ActiveSupport::CachingKeyGenerator.new(key_generator)
         secret            = key_generator.generate_key('encrypted cookie')
         sign_secret       = key_generator.generate_key('signed encrypted cookie')
-        encryptor         = ActiveSupport::MessageEncryptor.new(secret, sign_secret)
+        encryptor         = ActiveSupport::MessageEncryptor.new(secret, sign_secret, serializer: JSON)
         data              = encryptor.decrypt_and_verify(unescaped_content)
 
         if data['warden.user.user.key'].present?

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,0 +1,3 @@
+# Be sure to restart your server when you modify this file.
+
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid


### PR DESCRIPTION
Set the `cookies_serializer` to `:hybrid`
Specify the serializer when the cookie is decrypted and verified - `JSON`