### PR TITLE
BC-814: Ruby 2.0.0 is Sunsetting on Feb. 24, 2016

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 # if there is a super emergency and rubygems is playing up, try
 #source 'http://production.cf.rubygems.org'
 
+ruby '2.1.8'
+
 gem 'dotenv-rails', :groups => [:development, :test]
 
 module ::Kernel


### PR DESCRIPTION
### Summary
* [BC-814](https://lessonplanet.atlassian.net/browse/BC-814)
* added ruby version 2.1.8 to Gemfile
* 2.1.8 is the latest version compatible with our discourse version
* this version will be automatically installed by heroku